### PR TITLE
Improve reactive forms

### DIFF
--- a/frontend/src/app/common/forms/forms.ts
+++ b/frontend/src/app/common/forms/forms.ts
@@ -46,10 +46,6 @@ import { Observable } from 'rxjs';
   So, here comes a really simple attempt to fix this issue on our own.
 */
 
-type MyFormControls<T> = {
-  [key in keyof T]: MyGenericFormControl<T[key]>;
-};
-
 interface ControlUniquenessItem {
   /**
    * This element is used to allow the typechecker to distinguish "UseControl" elements from other ones.
@@ -63,9 +59,13 @@ interface ControlUniquenessItem {
 export type UseControl<T extends string[] | number[]> = T &
   ControlUniquenessItem;
 
-type FormValue<T> = {
+export type FormValue<T> = {
   // Remove the "ControlUniquenessItem" and make everything optional.
   [key in keyof T]?: T[key] extends UseControl<infer U> ? U : FormValue<T[key]>;
+};
+
+type MyFormControls<T> = {
+  [key in keyof T]: MyGenericFormControl<T[key]>;
 };
 
 type MyGenericFormControl<T> = T extends UseControl<infer U>

--- a/frontend/src/app/common/forms/forms.ts
+++ b/frontend/src/app/common/forms/forms.ts
@@ -270,6 +270,64 @@ export class FormArray<T> extends AngularFormArray {
  *
  * console.log(test.controls.address.controls.name.controls.firstName.value);
  * ```
+ *
+ * The structure of the form is defined by the Generics you see above.
+ *
+ * If the interface contains an object, then this leads to a FormGroup:
+ *
+ * ```
+ * interface MyModel {
+ *   bar: SomeObject;
+ * }
+ * interface SomeObject {
+ *   baz: (whatever);
+ *   frub: (whatever);
+ * }
+ *
+ * const form = new FormGroup<MyModel>({
+ *   bar: new FormGroup<SomeObject>({...})
+ * });
+ * ```
+ *
+ * If the interface contains a string or number, then this leads to a FormControl:
+ *
+ * ```
+ * interface MyModel {
+ *   bar: string;
+ *   baz: number;
+ * }
+ *
+ * const form = new FormGroup<MyModel>({
+ *   bar: new FormControl('hello'),
+ *   baz: new FormControl(123),
+ * });
+ * ```
+ *
+ * If the interface contains an array, then this leads to a FormArray:
+ *
+ * ```
+ * interface MyModel {
+ *   bar: string[];
+ * }
+ *
+ * const form = new FormGroup<MyModel>({
+ *   bar: new FormArray<string>([]);
+ * })
+ * ```
+ *
+ * But what if you want to use an array inside a FormControl? For this edge case, you can use the `UseControl` "hint":
+ *
+ * ```
+ * interface MyModel {
+ *   bar: string[];
+ *   baz: UseControl<string[]>;
+ * }
+ *
+ * const form = new FormGroup<MyModel>({
+ *   bar: new FormArray<string>([]),
+ *   baz: new FormControl<string[]>([]),
+ * })
+ * ```
  */
 export class FormGroup<T> extends AngularFormGroup {
   /**

--- a/frontend/src/app/common/forms/forms.ts
+++ b/frontend/src/app/common/forms/forms.ts
@@ -79,11 +79,27 @@ type MyGenericFormControl<T> = T extends UseControl<infer U>
   : never; // Anything else is not permitted.
 
 /**
- * A recursive Partial.
+ * A recursive "Required".
+ * (It makes all properties non-optional.)
+ *
+ * Example:
+ *
+ * ```
+ * interface Model {
+ *   foo?: {
+ *     bar?: string;
+ *   }
+ * }
+ *
+ * DeepRequired<Model> is now:
+ * {
+ *   foo: {
+ *     bar: string;
+ *   }
+ * }
+ * ```
  */
-type DeepPartial<T> = {
-  [key in keyof T]?: DeepPartial<T[key]>;
-};
+type DeepRequired<T> = { [key in keyof T]-?: DeepRequired<T[key]> };
 
 /**
  * In some methods of the Form Controls, you can either pass a raw value, or a value and a disabled state.
@@ -263,7 +279,7 @@ export class FormGroup<T> extends AngularFormGroup {
   /**
    * Important: The data passed in the Observable only includes currently not disabled elements.
    */
-  readonly valueChanges: Observable<DeepPartial<T>>;
+  readonly valueChanges: Observable<FormValue<T>>;
 
   constructor(
     public controls: MyFormControls<T>,
@@ -278,7 +294,7 @@ export class FormGroup<T> extends AngularFormGroup {
   }
 
   setValue(
-    value: T,
+    value: DeepRequired<FormValue<T>>,
     options?: {
       onlySelf?: boolean;
       emitEvent?: boolean;
@@ -288,7 +304,7 @@ export class FormGroup<T> extends AngularFormGroup {
   }
 
   patchValue(
-    value: DeepPartial<T>,
+    value: FormValue<T>,
     options?: {
       onlySelf?: boolean;
       emitEvent?: boolean;
@@ -300,7 +316,7 @@ export class FormGroup<T> extends AngularFormGroup {
   // It is actually also possible to pass an object containing, for each item, both the value and the disabled state.
   // Currently, we don't support this.
   reset(
-    value?: T,
+    value?: DeepRequired<FormValue<T>>,
     options?: {
       onlySelf?: boolean;
       emitEvent?: boolean;


### PR DESCRIPTION
We figured out that arrays cannot be used as values of FormControls. I fixed this by adding the "UseControl" hint. This is a pretty "hacky" approach, but at least it fixes our issue :)