### PR TITLE
Build the frontend using GitHub Actions

### DIFF
--- a/.github/workflows/frontend--lint-and-build.yml
+++ b/.github/workflows/frontend--lint-and-build.yml
@@ -29,4 +29,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: build-result
-          path: www/
+          path: frontend/www/

--- a/.github/workflows/frontend--lint-and-build.yml
+++ b/.github/workflows/frontend--lint-and-build.yml
@@ -1,4 +1,4 @@
-name: Lint the frontend
+name: Lint and build the frontend
 
 on:
   push:
@@ -24,3 +24,9 @@ jobs:
         run: npm install
       - name: Run all frontend checks
         run: npm run all-checks
+      - name: Build the frontend
+        run: npm run build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-result
+          path: www/


### PR DESCRIPTION
With this update to our GH Actions, the frontend will not only be linted, but now also built. The build result (currently for web only) will be stored as [build artifact](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts). So, you can then easily download the current build and, for instance, try it locally (on a dev server).

One additional advantage: If, for whatever reason, he linter passes, but the build fails, then we will also be able to see this now.

I did not use "ng build --prod", but only "ng build". Maybe, later on, it could be useful to generate a production build instead. But for now, I'd just leave it like this.

@Bharathravi1995 @denoribi Could one of you have a look at this and, if it is ok, merge it?